### PR TITLE
Modify the value of parameter "applicationInsightsConnectionString"

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -236,7 +236,7 @@ module functionAppWebSearcherPlugin './app/searcherplugin.bicep' = if (deployWeb
     name: !empty(functionAppWebName) ? functionAppWebName : '${abbrs.webSitesFunctions}${resourceToken}'
     location: location
     tags: union(tags, { 'azd-service-name': 'searcherplugin' }, { skweb: '1' })
-    applicationInsightsConnectionString: applicationInsights.outputs.instrumentationKey
+    applicationInsightsConnectionString: applicationInsights.outputs.connectionString
     appServicePlanId: appServicePlan.outputs.id
     strorageAccountName: storage.outputs.name
     webSearcherPackageUri: webSearcherPackageUri


### PR DESCRIPTION
Update `applicationInsights.outputs.instrumentationKey`  to `applicationInsights.outputs.connectionString`, because the value that needs to be passed is `ConnectionString`, not `key`.
![image](https://github.com/jongio/chat-copilot/assets/111940661/06a3ced5-6469-4947-a359-4958e348d1cb)

@jongio for notification.